### PR TITLE
Guard rm-prog-from-block-if-done against no-op writes

### DIFF
--- a/src/component.cljs
+++ b/src/component.cljs
@@ -332,10 +332,15 @@
     (str (if (< h 10) (str "0" h) h) ":" (if (< m 10) (str "0" m) m))))
 
 (defn rm-prog-from-block-if-done [uid]
-  (let [str (str/replace (get-block-str-naked uid) #"\sd\d{1,3}\%" "")]
-    (block/update {:block
-                   {:uid uid
-                    :string str}})))
+  (let [current  (get-block-str-naked uid)
+        stripped (str/replace current #"\sd\d{1,3}\%" "")]
+    ;; Only write when the marker was actually present. Without this guard the
+    ;; block is rewritten to an identical string on every render, churning
+    ;; :edit/time once per minute while a DNP is open.
+    (when (not= current stripped)
+      (block/update {:block
+                     {:uid uid
+                      :string stripped}}))))
 
 (defn update-block-progress [block-uid increment] 
    (let [s (get-block-str-naked block-uid)


### PR DESCRIPTION
rm-prog-from-block-if-done stripped the dNN% progress marker from DONE blocks and called block/update unconditionally. When a block has no marker (the common case), str/replace returns the identical string, so the block was rewritten to the same value -- which Roam still counts as an edit and bumps :edit/time.

Because this runs inside the parse/render path (parse-row-params -> populate-events -> main), and main re-renders ~once per minute on a DNP (now-time-atom timer) plus on any child-block change (reactive pull-watch in get-children-maps), every DONE block was rewritten continuously. This produced thousands of spurious edits per day, version-history noise, and constant sync activity.

Only write when the stripped string actually differs from the current block string, making the operation idempotent.